### PR TITLE
switch to stable repo with release of mono5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,11 @@ MAINTAINER sparklyballs
 # environment settings
 ARG DEBIAN_FRONTEND="noninteractive"
 
-# install packages
+# install packages
 RUN \
-# uses nightly repository as 4.8 mono currently has issues importing certificates
  apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 \
 	--recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
- echo "deb http://download.mono-project.com/repo/debian nightly main" \
+ echo "deb http://download.mono-project.com/repo/debian wheezy main" \
 	| tee /etc/apt/sources.list.d/mono-xamarin.list && \
  apt-get update && \
  apt-get install -y \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

+ bring armhf version to par with x86-64